### PR TITLE
refactor: add prisma types for customer queries

### DIFF
--- a/backend/src/modules/customers/controller.ts
+++ b/backend/src/modules/customers/controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import { validationResult } from 'express-validator';
 
 const prisma = new PrismaClient();
@@ -23,12 +23,12 @@ export class CustomerController {
       const skip = (pageNum - 1) * limitNum;
 
       // Filtreleme koşulları
-      const where: any = {
+      const where: Prisma.CustomerWhereInput = {
         userId: userId // Kullanıcıya özel müşteriler
       };
 
       if (type) {
-        where.type = type;
+        where.type = type as string;
       }
 
       if (search) {
@@ -40,8 +40,20 @@ export class CustomerController {
       }
 
       // Sıralama
-      const orderBy: any = {};
-      orderBy[sortBy as string] = sortOrder;
+      const orderBy: Prisma.CustomerOrderByWithRelationInput = (() => {
+        const order = sortOrder as Prisma.SortOrder;
+        switch (sortBy as string) {
+          case 'phone':
+            return { phone: order };
+          case 'createdAt':
+            return { createdAt: order };
+          case 'updatedAt':
+            return { updatedAt: order };
+          case 'name':
+          default:
+            return { name: order };
+        }
+      })();
 
       // Toplam kayıt sayısı
       const total = await prisma.customer.count({ where });


### PR DESCRIPTION
## Summary
- import Prisma types and annotate customer query builders
- validate sort field and apply typed orderBy logic

## Testing
- `npm run build` (fails: TS2322 etc.)
- `npx tsc src/modules/customers/controller.ts --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68935d72aa8483248a1e9dbd4b9e0619