### PR TITLE
Use UUIDs for customer codes

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -28,6 +28,7 @@
         "mailparser": "^3.6.5",
         "multer": "^1.4.5-lts.1",
         "sqlite3": "^5.1.7",
+        "uuid": "^11.1.0",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -1747,6 +1748,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/exceljs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/expand-template": {
@@ -4748,12 +4758,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,6 +39,7 @@
     "mailparser": "^3.6.5",
     "multer": "^1.4.5-lts.1",
     "sqlite3": "^5.1.7",
+    "uuid": "^11.1.0",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/backend/src/modules/customers/controller.ts
+++ b/backend/src/modules/customers/controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { validationResult } from 'express-validator';
+import { v4 as uuidv4 } from 'uuid';
 
 const prisma = new PrismaClient();
 
@@ -172,9 +173,14 @@ export class CustomerController {
 
       const userId = (req as any).user.id;
 
+      let code: string;
+      do {
+        code = `CUST_${uuidv4()}`;
+      } while (await prisma.customer.findUnique({ where: { code } }));
+
       const customer = await prisma.customer.create({
         data: {
-          code: `CUST_${Date.now()}`,
+          code,
           name,
           phone,
           address,


### PR DESCRIPTION
## Summary
- install `uuid` dependency
- generate unique customer codes with UUIDs and verify uniqueness

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Type 'number' is not assignable to type 'string' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68935d7358a8832496df654e8689ffe4