### PR TITLE
Validate numeric query params

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -39,6 +39,7 @@
         "@types/multer": "^1.4.11",
         "@types/node": "^20.10.5",
         "prisma": "^5.7.1",
+        "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.3.3"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "start": "node dist/index.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
-    "prisma:studio": "prisma studio"
+    "prisma:studio": "prisma studio",
+    "test": "node --require ts-node/register/transpile-only --test test"
   },
   "keywords": [
     "finansal",
@@ -51,6 +52,7 @@
     "@types/node": "^20.10.5",
     "prisma": "^5.7.1",
     "ts-node-dev": "^2.0.0",
+    "ts-node": "^10.9.1",
     "typescript": "^5.3.3"
   }
 }

--- a/backend/src/modules/banking/controller.ts
+++ b/backend/src/modules/banking/controller.ts
@@ -152,7 +152,22 @@ export class BankingController {
   async getBankTransactions(req: Request, res: Response) {
     try {
       const { page = 1, limit = 20, direction, isMatched } = req.query;
-      const skip = (Number(page) - 1) * Number(limit);
+      const pageNum = Number(page);
+      const limitNum = Number(limit);
+
+      if (
+        !Number.isInteger(pageNum) ||
+        !Number.isInteger(limitNum) ||
+        pageNum <= 0 ||
+        limitNum <= 0
+      ) {
+        return res.status(400).json({
+          success: false,
+          message: 'Sayfa ve limit pozitif tamsayı olmalıdır'
+        });
+      }
+
+      const skip = (pageNum - 1) * limitNum;
 
       const where: any = {};
       if (direction) where.direction = direction;
@@ -168,7 +183,7 @@ export class BankingController {
         },
         orderBy: { transactionDate: 'desc' },
         skip,
-        take: Number(limit)
+        take: limitNum
       });
 
       const total = await prisma.bankTransaction.count({ where });
@@ -176,10 +191,10 @@ export class BankingController {
       res.json({
         transactions,
         pagination: {
-          page: Number(page),
-          limit: Number(limit),
+          page: pageNum,
+          limit: limitNum,
           total,
-          pages: Math.ceil(total / Number(limit))
+          pages: Math.ceil(total / limitNum)
         }
       });
 
@@ -193,8 +208,16 @@ export class BankingController {
   async getUnmatchedPayments(req: Request, res: Response) {
     try {
       const { limit = 50 } = req.query;
-      
-      const transactions = await this.matchingService.getUnmatchedTransactions(Number(limit));
+      const limitNum = Number(limit);
+
+      if (!Number.isInteger(limitNum) || limitNum <= 0) {
+        return res.status(400).json({
+          success: false,
+          message: 'Limit pozitif tamsayı olmalıdır'
+        });
+      }
+
+      const transactions = await this.matchingService.getUnmatchedTransactions(limitNum);
 
       res.json({
         success: true,
@@ -345,8 +368,16 @@ export class BankingController {
   async runAutoMatching(req: Request, res: Response) {
     try {
       const { limit = 100 } = req.query;
-      
-      const unmatchedTransactions = await this.matchingService.getUnmatchedTransactions(Number(limit));
+      const limitNum = Number(limit);
+
+      if (!Number.isInteger(limitNum) || limitNum <= 0) {
+        return res.status(400).json({
+          success: false,
+          message: 'Limit pozitif tamsayı olmalıdır'
+        });
+      }
+
+      const unmatchedTransactions = await this.matchingService.getUnmatchedTransactions(limitNum);
       let matchedCount = 0;
 
       for (const transaction of unmatchedTransactions) {

--- a/backend/src/modules/cash/controller.ts
+++ b/backend/src/modules/cash/controller.ts
@@ -59,7 +59,22 @@ export class CashController {
     try {
       const userId = (req as any).user.id;
       const { page = 1, limit = 20, startDate, endDate } = req.query;
-      const skip = (Number(page) - 1) * Number(limit);
+      const pageNum = Number(page);
+      const limitNum = Number(limit);
+
+      if (
+        !Number.isInteger(pageNum) ||
+        !Number.isInteger(limitNum) ||
+        pageNum <= 0 ||
+        limitNum <= 0
+      ) {
+        return res.status(400).json({
+          success: false,
+          message: 'Sayfa ve limit pozitif tamsayı olmalıdır'
+        });
+      }
+
+      const skip = (pageNum - 1) * limitNum;
 
       const where: any = { userId };
       
@@ -74,7 +89,7 @@ export class CashController {
         where,
         orderBy: { date: 'desc' },
         skip,
-        take: Number(limit)
+        take: limitNum
       });
 
       const total = await prisma.cashFlow.count({ where });
@@ -82,10 +97,10 @@ export class CashController {
       res.json({
         cashFlows,
         pagination: {
-          page: Number(page),
-          limit: Number(limit),
+          page: pageNum,
+          limit: limitNum,
           total,
-          pages: Math.ceil(total / Number(limit))
+          pages: Math.ceil(total / limitNum)
         }
       });
 
@@ -344,7 +359,22 @@ export class CashController {
     try {
       const userId = (req as any).user.id;
       const { page = 1, limit = 20, startDate, endDate } = req.query;
-      const skip = (Number(page) - 1) * Number(limit);
+      const pageNum = Number(page);
+      const limitNum = Number(limit);
+
+      if (
+        !Number.isInteger(pageNum) ||
+        !Number.isInteger(limitNum) ||
+        pageNum <= 0 ||
+        limitNum <= 0
+      ) {
+        return res.status(400).json({
+          success: false,
+          message: 'Sayfa ve limit pozitif tamsayı olmalıdır'
+        });
+      }
+
+      const skip = (pageNum - 1) * limitNum;
 
       const where: any = {
         userId,
@@ -365,7 +395,7 @@ export class CashController {
         },
         orderBy: { date: 'desc' },
         skip,
-        take: Number(limit)
+        take: limitNum
       });
 
       const total = await prisma.transaction.count({ where });
@@ -373,10 +403,10 @@ export class CashController {
       res.json({
         transactions,
         pagination: {
-          page: Number(page),
-          limit: Number(limit),
+          page: pageNum,
+          limit: limitNum,
           total,
-          pages: Math.ceil(total / Number(limit))
+          pages: Math.ceil(total / limitNum)
         }
       });
 

--- a/backend/src/modules/categories/controller.ts
+++ b/backend/src/modules/categories/controller.ts
@@ -372,8 +372,15 @@ export class CategoryController {
     try {
       const { q, type, limit = 10 } = req.query;
       const searchQuery = q as string;
-      const limitNum = parseInt(limit as string);
+      const limitNum = Number(limit);
       const userId = (req as any).user.id;
+
+      if (!Number.isInteger(limitNum) || limitNum <= 0) {
+        return res.status(400).json({
+          success: false,
+          message: 'Limit pozitif tamsayı olmalıdır'
+        });
+      }
 
       if (!searchQuery || searchQuery.length < 2) {
         return res.json({

--- a/backend/src/modules/customers/controller.ts
+++ b/backend/src/modules/customers/controller.ts
@@ -18,8 +18,21 @@ export class CustomerController {
       } = req.query;
 
       const userId = (req as any).user.id;
-      const pageNum = parseInt(page as string);
-      const limitNum = parseInt(limit as string);
+      const pageNum = Number(page);
+      const limitNum = Number(limit);
+
+      if (
+        !Number.isInteger(pageNum) ||
+        !Number.isInteger(limitNum) ||
+        pageNum <= 0 ||
+        limitNum <= 0
+      ) {
+        return res.status(400).json({
+          success: false,
+          message: 'Sayfa ve limit pozitif tamsayı olmalıdır'
+        });
+      }
+
       const skip = (pageNum - 1) * limitNum;
 
       // Filtreleme koşulları
@@ -408,8 +421,15 @@ export class CustomerController {
     try {
       const { q, limit = 10 } = req.query;
       const searchQuery = q as string;
-      const limitNum = parseInt(limit as string);
+      const limitNum = Number(limit);
       const userId = (req as any).user.id;
+
+      if (!Number.isInteger(limitNum) || limitNum <= 0) {
+        return res.status(400).json({
+          success: false,
+          message: 'Limit pozitif tamsayı olmalıdır'
+        });
+      }
 
       if (!searchQuery || searchQuery.length < 2) {
         return res.json({

--- a/backend/src/modules/transactions/controller.ts
+++ b/backend/src/modules/transactions/controller.ts
@@ -21,8 +21,21 @@ export class TransactionController {
         search
       } = req.query;
 
-      const pageNum = parseInt(page as string);
-      const limitNum = parseInt(limit as string);
+      const pageNum = Number(page);
+      const limitNum = Number(limit);
+
+      if (
+        !Number.isInteger(pageNum) ||
+        !Number.isInteger(limitNum) ||
+        pageNum <= 0 ||
+        limitNum <= 0
+      ) {
+        return res.status(400).json({
+          success: false,
+          message: 'Sayfa ve limit pozitif tamsayı olmalıdır'
+        });
+      }
+
       const skip = (pageNum - 1) * limitNum;
 
       // Filtreleme koşulları

--- a/backend/test/pagination.test.js
+++ b/backend/test/pagination.test.js
@@ -1,0 +1,58 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// Mock PrismaClient to prevent actual database connections during tests
+const Module = require('module');
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function (path) {
+  if (path === '@prisma/client') {
+    return { PrismaClient: class {} };
+  }
+  return originalRequire.apply(this, arguments);
+};
+
+const { CustomerController } = require('../src/modules/customers/controller');
+const { TransactionController } = require('../src/modules/transactions/controller');
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test('getAllCustomers rejects non-positive page', async () => {
+  const req = { query: { page: '0', limit: '10' }, user: { id: 'u1' } };
+  const res = mockRes();
+  await CustomerController.getAllCustomers(req, res);
+  assert.equal(res.statusCode, 400);
+});
+
+test('getAllCustomers rejects non-positive limit', async () => {
+  const req = { query: { page: '1', limit: '0' }, user: { id: 'u1' } };
+  const res = mockRes();
+  await CustomerController.getAllCustomers(req, res);
+  assert.equal(res.statusCode, 400);
+});
+
+test('getAllTransactions rejects non-positive page', async () => {
+  const req = { query: { page: '-1', limit: '10' } };
+  const res = mockRes();
+  await TransactionController.getAllTransactions(req, res);
+  assert.equal(res.statusCode, 400);
+});
+
+test('getAllTransactions rejects non-positive limit', async () => {
+  const req = { query: { page: '1', limit: 'abc' } };
+  const res = mockRes();
+  await TransactionController.getAllTransactions(req, res);
+  assert.equal(res.statusCode, 400);
+});


### PR DESCRIPTION
## Summary
- ensure pagination params are positive integers across API controllers
- add test covering invalid page and limit values

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68935d7599048324a20b90b0a417ffc0