### PR TITLE
Add basic localization to customer controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ NODE_ENV=development
 FRONTEND_URL="http://localhost:3000"
 ```
 
+## 🌐 Localization
+
+Backend responses are localized using a simple message catalog. The system
+currently supports Turkish and English. The preferred language can be
+specified via the `Accept-Language` header (`tr` or `en`). To add or edit
+translations, update `backend/src/utils/i18n.ts`.
+
 ## 📊 Veritabanı Şeması
 
 ### Ana Tablolar

--- a/backend/src/modules/customers/controller.ts
+++ b/backend/src/modules/customers/controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { validationResult } from 'express-validator';
+import { t } from '../../utils/i18n';
 
 const prisma = new PrismaClient();
 
@@ -82,10 +83,10 @@ export class CustomerController {
         }
       });
     } catch (error) {
-      console.error('Müşteriler getirilirken hata:', error);
+      console.error(t(req, 'CUSTOMERS_FETCH_ERROR_LOG'), error);
       return res.status(500).json({
         success: false,
-        message: 'Müşteriler getirilirken bir hata oluştu'
+        message: t(req, 'CUSTOMERS_FETCH_ERROR')
       });
     }
   }
@@ -131,7 +132,7 @@ export class CustomerController {
       if (!customer) {
         return res.status(404).json({
           success: false,
-          message: 'Müşteri bulunamadı'
+          message: t(req, 'CUSTOMER_NOT_FOUND')
         });
       }
 
@@ -140,10 +141,10 @@ export class CustomerController {
         data: customer
       });
     } catch (error) {
-      console.error('Müşteri getirilirken hata:', error);
+      console.error(t(req, 'CUSTOMER_FETCH_ERROR_LOG'), error);
       return res.status(500).json({
         success: false,
-        message: 'Müşteri getirilirken bir hata oluştu'
+        message: t(req, 'CUSTOMER_FETCH_ERROR')
       });
     }
   }
@@ -155,7 +156,7 @@ export class CustomerController {
       if (!errors.isEmpty()) {
         return res.status(400).json({
           success: false,
-          message: 'Validasyon hatası',
+          message: t(req, 'VALIDATION_ERROR'),
           errors: errors.array()
         });
       }
@@ -188,14 +189,14 @@ export class CustomerController {
 
       return res.status(201).json({
         success: true,
-        message: 'Müşteri başarıyla oluşturuldu',
+        message: t(req, 'CUSTOMER_CREATE_SUCCESS'),
         data: customer
       });
     } catch (error) {
-      console.error('Müşteri oluşturulurken hata:', error);
+      console.error(t(req, 'CUSTOMER_CREATE_ERROR_LOG'), error);
       return res.status(500).json({
         success: false,
-        message: 'Müşteri oluşturulurken bir hata oluştu'
+        message: t(req, 'CUSTOMER_CREATE_ERROR')
       });
     }
   }
@@ -207,7 +208,7 @@ export class CustomerController {
       if (!errors.isEmpty()) {
         return res.status(400).json({
           success: false,
-          message: 'Validasyon hatası',
+          message: t(req, 'VALIDATION_ERROR'),
           errors: errors.array()
         });
       }
@@ -237,7 +238,7 @@ export class CustomerController {
       if (!existingCustomer) {
         return res.status(404).json({
           success: false,
-          message: 'Müşteri bulunamadı'
+          message: t(req, 'CUSTOMER_NOT_FOUND')
         });
       }
 
@@ -256,14 +257,14 @@ export class CustomerController {
 
       return res.json({
         success: true,
-        message: 'Müşteri başarıyla güncellendi',
+        message: t(req, 'CUSTOMER_UPDATE_SUCCESS'),
         data: customer
       });
     } catch (error) {
-      console.error('Müşteri güncellenirken hata:', error);
+      console.error(t(req, 'CUSTOMER_UPDATE_ERROR_LOG'), error);
       return res.status(500).json({
         success: false,
-        message: 'Müşteri güncellenirken bir hata oluştu'
+        message: t(req, 'CUSTOMER_UPDATE_ERROR')
       });
     }
   }
@@ -293,7 +294,7 @@ export class CustomerController {
       if (!existingCustomer) {
         return res.status(404).json({
           success: false,
-          message: 'Müşteri bulunamadı'
+          message: t(req, 'CUSTOMER_NOT_FOUND')
         });
       }
 
@@ -301,7 +302,7 @@ export class CustomerController {
       if (existingCustomer._count.transactions > 0) {
         return res.status(400).json({
           success: false,
-          message: 'İşlemleri olan müşteri silinemez'
+          message: t(req, 'CUSTOMER_DELETE_HAS_TRANSACTIONS')
         });
       }
 
@@ -311,13 +312,13 @@ export class CustomerController {
 
       return res.json({
         success: true,
-        message: 'Müşteri başarıyla silindi'
+        message: t(req, 'CUSTOMER_DELETE_SUCCESS')
       });
     } catch (error) {
-      console.error('Müşteri silinirken hata:', error);
+      console.error(t(req, 'CUSTOMER_DELETE_ERROR_LOG'), error);
       return res.status(500).json({
         success: false,
-        message: 'Müşteri silinirken bir hata oluştu'
+        message: t(req, 'CUSTOMER_DELETE_ERROR')
       });
     }
   }
@@ -340,7 +341,7 @@ export class CustomerController {
       if (!customer) {
         return res.status(404).json({
           success: false,
-          message: 'Müşteri bulunamadı'
+          message: t(req, 'CUSTOMER_NOT_FOUND')
         });
       }
 
@@ -395,10 +396,10 @@ export class CustomerController {
         }
       });
     } catch (error) {
-      console.error('Müşteri istatistikleri getirilirken hata:', error);
+      console.error(t(req, 'CUSTOMER_STATS_ERROR_LOG'), error);
       return res.status(500).json({
         success: false,
-        message: 'Müşteri istatistikleri getirilirken bir hata oluştu'
+        message: t(req, 'CUSTOMER_STATS_ERROR')
       });
     }
   }
@@ -441,10 +442,10 @@ export class CustomerController {
         data: customers
       });
     } catch (error) {
-      console.error('Müşteri arama hatası:', error);
+      console.error(t(req, 'CUSTOMER_SEARCH_ERROR_LOG'), error);
       return res.status(500).json({
         success: false,
-        message: 'Müşteri arama sırasında bir hata oluştu'
+        message: t(req, 'CUSTOMER_SEARCH_ERROR')
       });
     }
   }
@@ -458,7 +459,7 @@ export class CustomerController {
       if (!Array.isArray(ids) || ids.length === 0) {
         return res.status(400).json({
           success: false,
-          message: 'Geçerli ID listesi gerekli'
+          message: t(req, 'CUSTOMER_ID_LIST_REQUIRED')
         });
       }
 
@@ -480,7 +481,7 @@ export class CustomerController {
       if (customers.length !== ids.length) {
         return res.status(404).json({
           success: false,
-          message: 'Bazı müşteriler bulunamadı'
+          message: t(req, 'CUSTOMERS_NOT_FOUND')
         });
       }
 
@@ -488,7 +489,7 @@ export class CustomerController {
       if (customersWithTransactions.length > 0) {
         return res.status(400).json({
           success: false,
-          message: 'İşlemleri olan müşteriler silinemez'
+          message: t(req, 'CUSTOMERS_DELETE_HAS_TRANSACTIONS')
         });
       }
 
@@ -501,14 +502,14 @@ export class CustomerController {
 
       return res.json({
         success: true,
-        message: `${ids.length} müşteri başarıyla silindi`
+        message: t(req, 'CUSTOMERS_DELETE_SUCCESS', { count: ids.length })
       });
     } catch (error) {
-      console.error('Toplu müşteri silme hatası:', error);
+      console.error(t(req, 'CUSTOMERS_DELETE_ERROR_LOG'), error);
       return res.status(500).json({
         success: false,
-        message: 'Müşteriler silinirken bir hata oluştu'
+        message: t(req, 'CUSTOMERS_DELETE_ERROR')
       });
     }
   }
-} 
+}

--- a/backend/src/utils/i18n.ts
+++ b/backend/src/utils/i18n.ts
@@ -1,0 +1,87 @@
+import { Request } from 'express';
+
+const messages = {
+  tr: {
+    CUSTOMERS_FETCH_ERROR: 'Müşteriler getirilirken bir hata oluştu',
+    CUSTOMER_NOT_FOUND: 'Müşteri bulunamadı',
+    CUSTOMER_FETCH_ERROR: 'Müşteri getirilirken bir hata oluştu',
+    VALIDATION_ERROR: 'Validasyon hatası',
+    CUSTOMER_CREATE_SUCCESS: 'Müşteri başarıyla oluşturuldu',
+    CUSTOMER_CREATE_ERROR: 'Müşteri oluşturulurken bir hata oluştu',
+    CUSTOMER_UPDATE_SUCCESS: 'Müşteri başarıyla güncellendi',
+    CUSTOMER_UPDATE_ERROR: 'Müşteri güncellenirken bir hata oluştu',
+    CUSTOMER_DELETE_HAS_TRANSACTIONS: 'İşlemleri olan müşteri silinemez',
+    CUSTOMER_DELETE_ERROR: 'Müşteri silinirken bir hata oluştu',
+    CUSTOMER_DELETE_SUCCESS: 'Müşteri başarıyla silindi',
+    CUSTOMER_STATS_ERROR: 'Müşteri istatistikleri getirilirken bir hata oluştu',
+    CUSTOMER_SEARCH_ERROR: 'Müşteri arama sırasında bir hata oluştu',
+    CUSTOMER_ID_LIST_REQUIRED: 'Geçerli ID listesi gerekli',
+    CUSTOMERS_NOT_FOUND: 'Bazı müşteriler bulunamadı',
+    CUSTOMERS_DELETE_HAS_TRANSACTIONS: 'İşlemleri olan müşteriler silinemez',
+    CUSTOMERS_DELETE_SUCCESS: '{count} müşteri başarıyla silindi',
+    CUSTOMERS_DELETE_ERROR: 'Müşteriler silinirken bir hata oluştu',
+    CUSTOMERS_FETCH_ERROR_LOG: 'Müşteriler getirilirken hata:',
+    CUSTOMER_FETCH_ERROR_LOG: 'Müşteri getirilirken hata:',
+    CUSTOMER_CREATE_ERROR_LOG: 'Müşteri oluşturulurken hata:',
+    CUSTOMER_UPDATE_ERROR_LOG: 'Müşteri güncellenirken hata:',
+    CUSTOMER_DELETE_ERROR_LOG: 'Müşteri silinirken hata:',
+    CUSTOMER_STATS_ERROR_LOG: 'Müşteri istatistikleri getirilirken hata:',
+    CUSTOMER_SEARCH_ERROR_LOG: 'Müşteri arama hatası:',
+    CUSTOMERS_DELETE_ERROR_LOG: 'Toplu müşteri silme hatası:'
+  },
+  en: {
+    CUSTOMERS_FETCH_ERROR: 'An error occurred while fetching customers',
+    CUSTOMER_NOT_FOUND: 'Customer not found',
+    CUSTOMER_FETCH_ERROR: 'An error occurred while fetching the customer',
+    VALIDATION_ERROR: 'Validation error',
+    CUSTOMER_CREATE_SUCCESS: 'Customer created successfully',
+    CUSTOMER_CREATE_ERROR: 'An error occurred while creating the customer',
+    CUSTOMER_UPDATE_SUCCESS: 'Customer updated successfully',
+    CUSTOMER_UPDATE_ERROR: 'An error occurred while updating the customer',
+    CUSTOMER_DELETE_HAS_TRANSACTIONS: 'Cannot delete a customer with transactions',
+    CUSTOMER_DELETE_ERROR: 'An error occurred while deleting the customer',
+    CUSTOMER_DELETE_SUCCESS: 'Customer deleted successfully',
+    CUSTOMER_STATS_ERROR: 'An error occurred while fetching customer statistics',
+    CUSTOMER_SEARCH_ERROR: 'An error occurred during customer search',
+    CUSTOMER_ID_LIST_REQUIRED: 'A valid ID list is required',
+    CUSTOMERS_NOT_FOUND: 'Some customers were not found',
+    CUSTOMERS_DELETE_HAS_TRANSACTIONS: 'Customers with transactions cannot be deleted',
+    CUSTOMERS_DELETE_SUCCESS: '{count} customers deleted successfully',
+    CUSTOMERS_DELETE_ERROR: 'An error occurred while deleting customers',
+    CUSTOMERS_FETCH_ERROR_LOG: 'Error fetching customers:',
+    CUSTOMER_FETCH_ERROR_LOG: 'Error fetching customer:',
+    CUSTOMER_CREATE_ERROR_LOG: 'Error creating customer:',
+    CUSTOMER_UPDATE_ERROR_LOG: 'Error updating customer:',
+    CUSTOMER_DELETE_ERROR_LOG: 'Error deleting customer:',
+    CUSTOMER_STATS_ERROR_LOG: 'Error fetching customer statistics:',
+    CUSTOMER_SEARCH_ERROR_LOG: 'Customer search error:',
+    CUSTOMERS_DELETE_ERROR_LOG: 'Bulk customer delete error:'
+  }
+} as const;
+
+export type Locale = keyof typeof messages;
+export type MessageKey = keyof typeof messages['tr'];
+
+function getLocale(req: Request): Locale {
+  const header = req.headers['accept-language'];
+  if (typeof header === 'string') {
+    const locale = header.split(',')[0].split('-')[0] as Locale;
+    if (locale in messages) {
+      return locale;
+    }
+  }
+  return 'tr';
+}
+
+export function t(req: Request, key: MessageKey, vars?: Record<string, string | number>): string {
+  const locale = getLocale(req);
+  let text: string = messages[locale][key] || key;
+  if (vars) {
+    for (const [k, v] of Object.entries(vars)) {
+      text = text.replace(`{${k}}`, String(v));
+    }
+  }
+  return text;
+}
+
+export default { t };


### PR DESCRIPTION
## Summary
- add i18n utility with Turkish and English catalogs
- localize customer controller messages via new `t` helper
- document localization usage in README

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: 87 errors in unrelated modules)


------
https://chatgpt.com/codex/tasks/task_e_68935f31e8508324bf25bc7c3963d336