### PR TITLE
Validate customer sort field

### DIFF
--- a/backend/src/modules/customers/controller.ts
+++ b/backend/src/modules/customers/controller.ts
@@ -2,6 +2,10 @@ import { Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { validationResult } from 'express-validator';
 
+// Allowed fields for sorting customers
+export type CustomerSortField = 'name' | 'phone' | 'address' | 'type';
+const ALLOWED_SORT_FIELDS: CustomerSortField[] = ['name', 'phone', 'address', 'type'];
+
 const prisma = new PrismaClient();
 
 export class CustomerController {
@@ -16,6 +20,14 @@ export class CustomerController {
         sortBy = 'name',
         sortOrder = 'asc'
       } = req.query;
+
+      const sortField = sortBy as string;
+      if (!ALLOWED_SORT_FIELDS.includes(sortField as CustomerSortField)) {
+        return res.status(400).json({
+          success: false,
+          message: 'Ge\u00e7erli bir s\u0131ralama alan\u0131 giriniz'
+        });
+      }
 
       const userId = (req as any).user.id;
       const pageNum = parseInt(page as string);
@@ -40,8 +52,8 @@ export class CustomerController {
       }
 
       // Sıralama
-      const orderBy: any = {};
-      orderBy[sortBy as string] = sortOrder;
+      const orderBy: { [key in CustomerSortField]?: 'asc' | 'desc' } = {};
+      orderBy[sortField as CustomerSortField] = sortOrder as 'asc' | 'desc';
 
       // Toplam kayıt sayısı
       const total = await prisma.customer.count({ where });

--- a/backend/src/modules/customers/routes.ts
+++ b/backend/src/modules/customers/routes.ts
@@ -67,7 +67,7 @@ const queryValidation = [
     .withMessage('Arama terimi 1-100 karakter arasında olmalıdır'),
   query('sortBy')
     .optional()
-    .isIn(['name', 'email', 'phone', 'createdAt', 'updatedAt'])
+    .isIn(['name', 'phone', 'address', 'type'])
     .withMessage('Geçerli bir sıralama alanı giriniz'),
   query('sortOrder')
     .optional()

--- a/backend/test/customer-sort.test.ts
+++ b/backend/test/customer-sort.test.ts
@@ -1,0 +1,55 @@
+import assert from 'assert';
+import Module from 'module';
+
+// Prisma'yı mock'layarak gerçek veritabanı bağlantısını engelle
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function (id: string) {
+  if (id === '@prisma/client') {
+    return {
+      PrismaClient: class {
+        customer = { count: async () => 0, findMany: async () => [] };
+      }
+    };
+  }
+  return originalRequire.apply(this, arguments as any);
+};
+
+// Controller'ı mock'tan sonra import etmeliyiz
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { CustomerController } = require('../src/modules/customers/controller');
+
+// Basit bir mock Response sınıfı
+class MockResponse {
+  statusCode: number = 200;
+  body: any;
+
+  status(code: number) {
+    this.statusCode = code;
+    return this;
+  }
+
+  json(payload: any) {
+    this.body = payload;
+    return this;
+  }
+}
+
+async function runInvalidSortByTest() {
+  const req: any = {
+    query: { sortBy: 'invalid', page: '1', limit: '10' },
+    user: { id: 1 }
+  };
+  const res = new MockResponse();
+
+  await CustomerController.getAllCustomers(req, res as any);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  console.log('invalid sortBy test passed');
+}
+
+runInvalidSortByTest().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- enforce allowed sort fields via CustomerSortField union and runtime check
- reject invalid sortBy values and apply typed orderBy
- add test covering invalid sortBy handling

## Testing
- `npx ts-node --transpile-only backend/test/customer-sort.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68935f3559408324897c7e1f0e4ae734