### PR TITLE
feat(customers): add typed DTO validation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "start": "node dist/index.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
-    "prisma:studio": "prisma studio"
+    "prisma:studio": "prisma studio",
+    "test": "tsc --noEmit src/modules/customers/dto.ts src/modules/customers/dto.test.ts"
   },
   "keywords": [
     "finansal",

--- a/backend/src/modules/customers/controller.ts
+++ b/backend/src/modules/customers/controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { validationResult } from 'express-validator';
+import { CreateCustomerDto, UpdateCustomerDto } from './dto';
 
 const prisma = new PrismaClient();
 
@@ -168,7 +169,7 @@ export class CustomerController {
         accountType,
         tag1,
         tag2
-      } = req.body;
+      }: CreateCustomerDto = req.body;
 
       const userId = (req as any).user.id;
 
@@ -224,7 +225,7 @@ export class CustomerController {
         accountType,
         tag1,
         tag2
-      } = req.body;
+      }: UpdateCustomerDto = req.body;
 
       // Müşterinin var olup olmadığını kontrol et
       const existingCustomer = await prisma.customer.findFirst({

--- a/backend/src/modules/customers/dto.test.ts
+++ b/backend/src/modules/customers/dto.test.ts
@@ -1,0 +1,28 @@
+import { CreateCustomerDto, UpdateCustomerDto } from './dto';
+
+// Valid examples should compile without errors
+const validCreate: CreateCustomerDto = {
+  name: 'Test Customer',
+  phone: '1234567890'
+};
+
+const validUpdate: UpdateCustomerDto = {
+  address: 'Somewhere'
+};
+
+// Invalid shapes should trigger TypeScript errors
+// @ts-expect-error - missing required name field
+const invalidCreate: CreateCustomerDto = {
+  phone: '1234567890'
+};
+
+const extraField: CreateCustomerDto = {
+  name: 'Another',
+  // @ts-expect-error - property not defined in DTO
+  unknown: 'value'
+};
+
+const wrongType: UpdateCustomerDto = {
+  // @ts-expect-error - wrong type for phone
+  phone: 12345
+};

--- a/backend/src/modules/customers/dto.ts
+++ b/backend/src/modules/customers/dto.ts
@@ -1,0 +1,19 @@
+export interface CreateCustomerDto {
+  name: string;
+  phone?: string;
+  address?: string;
+  type?: 'INDIVIDUAL' | 'COMPANY';
+  accountType?: string;
+  tag1?: string;
+  tag2?: string;
+}
+
+export interface UpdateCustomerDto {
+  name?: string;
+  phone?: string;
+  address?: string;
+  type?: 'INDIVIDUAL' | 'COMPANY';
+  accountType?: string;
+  tag1?: string;
+  tag2?: string;
+}

--- a/backend/src/modules/customers/routes.ts
+++ b/backend/src/modules/customers/routes.ts
@@ -11,10 +11,6 @@ const customerValidation = [
     .trim()
     .isLength({ min: 1, max: 100 })
     .withMessage('Müşteri adı 1-100 karakter arasında olmalıdır'),
-  body('email')
-    .optional()
-    .isEmail()
-    .withMessage('Geçerli bir email adresi giriniz'),
   body('phone')
     .optional()
     .trim()
@@ -26,18 +22,24 @@ const customerValidation = [
     .isLength({ max: 500 })
     .withMessage('Adres 500 karakterden az olmalıdır'),
   body('type')
+    .optional()
     .isIn(['INDIVIDUAL', 'COMPANY'])
     .withMessage('Müşteri türü INDIVIDUAL veya COMPANY olmalıdır'),
-  body('taxNumber')
+  body('accountType')
+    .optional()
+    .trim()
+    .isLength({ max: 100 })
+    .withMessage('Hesap tipi 100 karakterden az olmalıdır'),
+  body('tag1')
     .optional()
     .trim()
     .isLength({ max: 50 })
-    .withMessage('Vergi numarası 50 karakterden az olmalıdır'),
-  body('notes')
+    .withMessage('Etiket 1 50 karakterden az olmalıdır'),
+  body('tag2')
     .optional()
     .trim()
-    .isLength({ max: 1000 })
-    .withMessage('Notlar 1000 karakterden az olmalıdır')
+    .isLength({ max: 50 })
+    .withMessage('Etiket 2 50 karakterden az olmalıdır')
 ];
 
 const updateCustomerValidation = [
@@ -67,7 +69,7 @@ const queryValidation = [
     .withMessage('Arama terimi 1-100 karakter arasında olmalıdır'),
   query('sortBy')
     .optional()
-    .isIn(['name', 'email', 'phone', 'createdAt', 'updatedAt'])
+    .isIn(['name', 'phone', 'createdAt', 'updatedAt'])
     .withMessage('Geçerli bir sıralama alanı giriniz'),
   query('sortOrder')
     .optional()


### PR DESCRIPTION
## Summary
- add `CreateCustomerDto` and `UpdateCustomerDto`
- enforce DTO usage in customer controller
- align express-validator rules and add type test

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68935f3741e88324a06b067c1411f727