### PR TITLE
Add customer payment performance report and frontend view

### DIFF
--- a/backend/src/modules/reports/routes.ts
+++ b/backend/src/modules/reports/routes.ts
@@ -66,6 +66,9 @@ router.get('/customer', authMiddleware, [
   ...limitValidation
 ], ReportController.getCustomerReport);
 
+// Müşteri ödeme performansı raporu
+router.get('/customer-payment-performance', authMiddleware, dateValidation, ReportController.getCustomerPaymentPerformance);
+
 // Günlük trend raporu
 router.get('/daily-trend', authMiddleware, requiredDateValidation, ReportController.getDailyTrend);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ import Extracts from './pages/Extracts'
 import Banking from './pages/Banking'
 import Cash from './pages/Cash'
 import ExtractDetail from './pages/ExtractDetail'
+import CustomerPaymentPerformance from './pages/reports/CustomerPaymentPerformance'
 
 // Protected Route bileşeni
 const ProtectedRoute = ({ children }) => {
@@ -62,6 +63,7 @@ const AppContent = () => {
         <Route path="extracts/:id" element={<ExtractDetail />} />
         <Route path="import" element={<Import />} />
         <Route path="reports" element={<Reports />} />
+        <Route path="reports/customer-payment-performance" element={<CustomerPaymentPerformance />} />
         <Route path="unpaid-invoices" element={<UnpaidInvoices />} />
         <Route path="paid-invoices" element={<PaidInvoices />} />
         <Route path="cash" element={<Cash />} />

--- a/frontend/src/pages/reports/CustomerPaymentPerformance.jsx
+++ b/frontend/src/pages/reports/CustomerPaymentPerformance.jsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react'
+import toast from 'react-hot-toast'
+import reportService from '../../services/reportService'
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+
+const CustomerPaymentPerformance = () => {
+  const [data, setData] = useState([])
+  const [loading, setLoading] = useState(false)
+
+  const loadData = async () => {
+    try {
+      setLoading(true)
+      const response = await reportService.getCustomerPaymentPerformance()
+      if (response.data.success) {
+        setData(response.data.data)
+      }
+    } catch (error) {
+      console.error('Veriler yüklenirken hata:', error)
+      toast.error('Veriler yüklenirken hata oluştu')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  const formatNumber = (num) => Number(num).toFixed(2)
+
+  const chartData = data.map(item => ({
+    name: item.customer.name,
+    late: item.lateInvoicePercentage
+  }))
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Müşteri Ödeme Performansı</h1>
+          <p className="text-gray-600">Müşterilerin ödeme süreleri ve gecikme oranları</p>
+        </div>
+        <button className="btn btn-secondary btn-md" onClick={loadData} disabled={loading}>
+          Yenile
+        </button>
+      </div>
+
+      <div className="card">
+        <div className="card-content">
+          {loading ? (
+            <div className="flex items-center justify-center h-48">
+              <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-primary-600"></div>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              <div className="overflow-x-auto">
+                <table className="table-auto w-full text-left">
+                  <thead>
+                    <tr>
+                      <th className="px-4 py-2">Müşteri</th>
+                      <th className="px-4 py-2">Toplam Fatura</th>
+                      <th className="px-4 py-2">Ödenen Fatura</th>
+                      <th className="px-4 py-2">Ort. Ödeme Günü</th>
+                      <th className="px-4 py-2">Gecikme %</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.map(item => (
+                      <tr key={item.customer.id} className="border-t">
+                        <td className="px-4 py-2">{item.customer.name}</td>
+                        <td className="px-4 py-2">{item.totalInvoices}</td>
+                        <td className="px-4 py-2">{item.paidInvoices}</td>
+                        <td className="px-4 py-2">{formatNumber(item.averagePaymentDays)}</td>
+                        <td className="px-4 py-2">{formatNumber(item.lateInvoicePercentage)}%</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {data.length > 0 && (
+                <div className="h-80">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={chartData}>
+                      <XAxis dataKey="name" interval={0} angle={-45} textAnchor="end" height={80} />
+                      <YAxis />
+                      <Tooltip formatter={(value) => `${formatNumber(value)}%`} />
+                      <Bar dataKey="late" fill="#f87171" />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CustomerPaymentPerformance
+

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -31,6 +31,11 @@ const reportService = {
     return apiClient.get('/reports/cash-flow', { params })
   },
 
+  // Müşteri ödeme performansı
+  getCustomerPaymentPerformance: (params = {}) => {
+    return apiClient.get('/reports/customer-payment-performance', { params })
+  },
+
   // Ödenmemiş faturalar raporu
   getUnpaidInvoices: (params = '') => {
     return apiClient.get(`/reports/unpaid-invoices?${params}`)


### PR DESCRIPTION
## Summary
- compute per-customer payment performance from extract transactions
- expose `/reports/customer-payment-performance` endpoint and service
- add customer payment performance page with table and late invoice chart

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6897071a6a08832486a918b518987132