### PR TITLE
Expose additional customer fields with filtering

### DIFF
--- a/backend/src/modules/customers/controller.ts
+++ b/backend/src/modules/customers/controller.ts
@@ -14,12 +14,17 @@ export class CustomerController {
    */
   getCustomers = async (req: Request, res: Response) => {
     try {
-      const { page, limit, sortBy, sortOrder } = req.query;
+      const { page, limit, sortBy, sortOrder, address, accountType, tag1, tag2, isActive } = req.query;
       const params = {
         page: page ? parseInt(page as string) : 1,
         limit: limit ? parseInt(limit as string) : 10,
         sortBy: sortBy as string,
-        sortOrder: sortOrder as 'asc' | 'desc'
+        sortOrder: sortOrder as 'asc' | 'desc',
+        address: (address as string) || undefined,
+        accountType: (accountType as string) || undefined,
+        tag1: (tag1 as string) || undefined,
+        tag2: (tag2 as string) || undefined,
+        isActive: typeof isActive === 'string' && isActive !== '' ? isActive === 'true' : undefined
       };
 
       // Kullanıcı ID'sini request'ten al

--- a/frontend/src/pages/Customers.jsx
+++ b/frontend/src/pages/Customers.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { PlusIcon, SearchIcon, FilterIcon } from 'lucide-react';
+import { PlusIcon, SearchIcon } from 'lucide-react';
 import { usePaginatedQuery, useApiDelete } from '../shared/hooks/useApi';
 import DataTable from '../shared/components/DataTable';
 import Modal from '../components/Modal';
@@ -11,6 +11,13 @@ const Customers = () => {
   const [showModal, setShowModal] = useState(false);
   const [editingCustomer, setEditingCustomer] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');
+  const [filters, setFilters] = useState({
+    address: '',
+    accountType: '',
+    tag1: '',
+    tag2: '',
+    isActive: ''
+  });
 
   // Müşteri listesi
   const {
@@ -22,7 +29,7 @@ const Customers = () => {
   } = usePaginatedQuery(
     ['customers'],
     '/customers',
-    { search: searchTerm },
+    { search: searchTerm, ...filters },
     {
       enabled: true,
     }
@@ -59,6 +66,50 @@ const Customers = () => {
       key: 'type',
       label: 'Tür',
       render: (value) => value === 'INDIVIDUAL' ? 'Bireysel' : 'Kurumsal',
+    },
+    {
+      key: 'address',
+      label: 'Adres',
+      sortable: true,
+      render: (value) => value || '-',
+      filterable: true,
+      filterType: 'text',
+    },
+    {
+      key: 'accountType',
+      label: 'Hesap Tipi',
+      sortable: true,
+      render: (value) => value || '-',
+      filterable: true,
+      filterType: 'text',
+    },
+    {
+      key: 'tag1',
+      label: 'Etiket 1',
+      sortable: true,
+      render: (value) => value || '-',
+      filterable: true,
+      filterType: 'text',
+    },
+    {
+      key: 'tag2',
+      label: 'Etiket 2',
+      sortable: true,
+      render: (value) => value || '-',
+      filterable: true,
+      filterType: 'text',
+    },
+    {
+      key: 'isActive',
+      label: 'Aktif',
+      sortable: true,
+      render: (value) => (value ? 'Evet' : 'Hayır'),
+      filterable: true,
+      filterType: 'select',
+      filterOptions: [
+        { value: 'true', label: 'Evet' },
+        { value: 'false', label: 'Hayır' },
+      ],
     },
     {
       key: 'balance',
@@ -111,6 +162,10 @@ const Customers = () => {
     if (window.confirm('Bu müşteriyi silmek istediğinizden emin misiniz?')) {
       deleteMutation.mutate(`/customers/${customerId}`);
     }
+  };
+
+  const handleFilterChange = (key, value) => {
+    setFilters(prev => ({ ...prev, [key]: value }));
   };
 
   // Modal kapatma
@@ -211,6 +266,8 @@ const Customers = () => {
         pagination={customersData?.data?.pagination}
         onPageChange={handlePageChange}
         onSortChange={handleSortChange}
+        filters={filters}
+        onFilterChange={handleFilterChange}
         loading={isLoading}
         emptyMessage="Müşteri bulunamadı"
       />

--- a/frontend/src/shared/components/DataTable.jsx
+++ b/frontend/src/shared/components/DataTable.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 import { ChevronLeftIcon, ChevronRightIcon, ChevronUpIcon, ChevronDownIcon } from 'lucide-react';
 
 const DataTable = ({
@@ -7,6 +7,8 @@ const DataTable = ({
   pagination = null,
   onPageChange,
   onSortChange,
+  filters = {},
+  onFilterChange,
   loading = false,
   emptyMessage = 'Veri bulunamadı',
   className = ''
@@ -31,6 +33,10 @@ const DataTable = ({
     return sortConfig.direction === 'asc' 
       ? <ChevronUpIcon className="w-4 h-4 text-blue-600" />
       : <ChevronDownIcon className="w-4 h-4 text-blue-600" />;
+  };
+
+  const handleFilter = (key, value) => {
+    onFilterChange?.(key, value);
   };
 
   // Sayfalama kontrolleri
@@ -126,6 +132,37 @@ const DataTable = ({
                 </th>
               ))}
             </tr>
+            {columns.some(col => col.filterable) && (
+              <tr>
+                {columns.map((column) => (
+                  <th key={column.key} className="px-4 py-2">
+                    {column.filterable ? (
+                      column.filterType === 'select' ? (
+                        <select
+                          value={filters[column.key] || ''}
+                          onChange={(e) => handleFilter(column.key, e.target.value)}
+                          className="border-gray-300 rounded-md text-sm"
+                        >
+                          <option value="">Hepsi</option>
+                          {column.filterOptions?.map((opt) => (
+                            <option key={opt.value} value={opt.value}>
+                              {opt.label}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <input
+                          type="text"
+                          value={filters[column.key] || ''}
+                          onChange={(e) => handleFilter(column.key, e.target.value)}
+                          className="border-gray-300 rounded-md text-sm w-full"
+                        />
+                      )
+                    ) : null}
+                  </th>
+                ))}
+              </tr>
+            )}
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {data.length === 0 ? (

--- a/frontend/src/shared/types/index.ts
+++ b/frontend/src/shared/types/index.ts
@@ -112,6 +112,9 @@ export interface TableColumn<T> {
   sortable?: boolean;
   render?: (value: any, record: T) => React.ReactNode;
   width?: string;
+  filterable?: boolean;
+  filterType?: 'text' | 'select';
+  filterOptions?: { value: string; label: string }[];
 }
 
 // Filtre tipleri


### PR DESCRIPTION
## Summary
- expose address, account type, tag1, tag2 and active status in customer API
- show new customer fields as sortable/filterable columns
- add column filter support to DataTable component

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689da229db588324a5bce30dc084703c