### PR TITLE
Add customer filters for type, activity, and debt

### DIFF
--- a/backend/src/modules/customers/controller.ts
+++ b/backend/src/modules/customers/controller.ts
@@ -14,7 +14,7 @@ export class CustomerController {
    */
   getCustomers = async (req: Request, res: Response) => {
     try {
-      const { page, limit, sortBy, sortOrder, address, accountType, tag1, tag2, isActive } = req.query;
+      const { page, limit, sortBy, sortOrder, address, accountType, tag1, tag2, isActive, type, hasDebt } = req.query;
       const params = {
         page: page ? parseInt(page as string) : 1,
         limit: limit ? parseInt(limit as string) : 10,
@@ -24,7 +24,9 @@ export class CustomerController {
         accountType: (accountType as string) || undefined,
         tag1: (tag1 as string) || undefined,
         tag2: (tag2 as string) || undefined,
-        isActive: typeof isActive === 'string' && isActive !== '' ? isActive === 'true' : undefined
+        isActive: typeof isActive === 'string' && isActive !== '' ? isActive === 'true' : undefined,
+        type: (type as string) || undefined,
+        hasDebt: typeof hasDebt === 'string' && hasDebt !== '' ? hasDebt === 'true' : undefined
       };
 
       // Kullanıcı ID'sini request'ten al

--- a/backend/src/modules/customers/service.ts
+++ b/backend/src/modules/customers/service.ts
@@ -14,12 +14,14 @@ export class CustomerService extends BaseService {
       tag1?: string;
       tag2?: string;
       isActive?: boolean;
+      type?: string;
+      hasDebt?: boolean;
     },
     userId?: string
   ): Promise<ApiResponse<PaginatedResponse<Customer>>> {
     return this.safeDatabaseOperation(async () => {
       const { page, limit, sortBy, sortOrder } = this.validatePaginationParams(params);
-      const { address, accountType, tag1, tag2, isActive } = params;
+      const { address, accountType, tag1, tag2, isActive, type, hasDebt } = params;
       const skip = (page - 1) * limit;
 
       // Kullanıcıya ve filtrelere özel sorgu
@@ -29,6 +31,12 @@ export class CustomerService extends BaseService {
       if (tag1) whereClause.tag1 = { contains: tag1 };
       if (tag2) whereClause.tag2 = { contains: tag2 };
       if (typeof isActive === 'boolean') whereClause.isActive = isActive;
+      if (type) whereClause.type = type;
+      if (typeof hasDebt === 'boolean') {
+        whereClause.balance = {
+          is: { netBalance: hasDebt ? { lt: 0 } : { gte: 0 } }
+        };
+      }
 
       const [customers, total] = await Promise.all([
         this.prisma.customer.findMany({

--- a/frontend/src/pages/Customers.jsx
+++ b/frontend/src/pages/Customers.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { PlusIcon, SearchIcon } from 'lucide-react';
+import { PlusIcon, SearchIcon, FilterIcon } from 'lucide-react';
 import { usePaginatedQuery, useApiDelete } from '../shared/hooks/useApi';
 import DataTable from '../shared/components/DataTable';
 import Modal from '../components/Modal';
@@ -16,8 +16,11 @@ const Customers = () => {
     accountType: '',
     tag1: '',
     tag2: '',
-    isActive: ''
+    isActive: '',
+    type: '',
+    hasDebt: ''
   });
+  const [showFilterPanel, setShowFilterPanel] = useState(false);
 
   // Müşteri listesi
   const {
@@ -206,7 +209,7 @@ const Customers = () => {
           </p>
         </div>
         
-        <div className="mt-4 sm:mt-0 flex space-x-3">
+        <div className="mt-4 sm:mt-0 flex space-x-3 items-center">
           <div className="relative">
             <SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
             <input
@@ -217,7 +220,57 @@ const Customers = () => {
               className="pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
-          
+
+          <div className="relative">
+            <button
+              onClick={() => setShowFilterPanel(!showFilterPanel)}
+              className="inline-flex items-center px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-700 hover:bg-gray-50"
+            >
+              <FilterIcon className="w-4 h-4" />
+            </button>
+
+            {showFilterPanel && (
+              <div className="absolute right-0 mt-2 w-64 bg-white border border-gray-200 rounded-md shadow-lg p-4 z-10">
+                <div className="mb-4">
+                  <label className="block text-sm font-medium text-gray-700">Müşteri Türü</label>
+                  <select
+                    value={filters.type}
+                    onChange={(e) => handleFilterChange('type', e.target.value)}
+                    className="mt-1 block w-full rounded-md border-gray-300"
+                  >
+                    <option value="">Tümü</option>
+                    <option value="INDIVIDUAL">Bireysel</option>
+                    <option value="COMPANY">Kurumsal</option>
+                  </select>
+                </div>
+                <div className="mb-4">
+                  <label className="block text-sm font-medium text-gray-700">Aktiflik</label>
+                  <select
+                    value={filters.isActive}
+                    onChange={(e) => handleFilterChange('isActive', e.target.value)}
+                    className="mt-1 block w-full rounded-md border-gray-300"
+                  >
+                    <option value="">Tümü</option>
+                    <option value="true">Aktif</option>
+                    <option value="false">Pasif</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">Borç Durumu</label>
+                  <select
+                    value={filters.hasDebt}
+                    onChange={(e) => handleFilterChange('hasDebt', e.target.value)}
+                    className="mt-1 block w-full rounded-md border-gray-300"
+                  >
+                    <option value="">Tümü</option>
+                    <option value="true">Borçlu</option>
+                    <option value="false">Borcu Yok</option>
+                  </select>
+                </div>
+              </div>
+            )}
+          </div>
+
           <button
             onClick={handleAddNew}
             className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"


### PR DESCRIPTION
## Summary
- add dropdown panel with `FilterIcon` to select customer type, active status, and debt state
- forward selected filters to the paginated customer query
- extend customer controller/service to apply type, active, and debt filters in DB queries

## Testing
- ❌ `npm test` (backend, 2 failing tests)
- ⚠️ `npm test` (frontend, missing script)
- ⚠️ `npm run lint` (frontend, ESLint configuration missing)


------
https://chatgpt.com/codex/tasks/task_e_689da67b4d008324b2b8e7f82f15b4d2